### PR TITLE
Add exclude path segment property for FileCommenter

### DIFF
--- a/config/sql-commenter.php
+++ b/config/sql-commenter.php
@@ -13,7 +13,7 @@ return [
         Spatie\SqlCommenter\Commenters\ControllerCommenter::class => ['includeNamespace' => false],
         Spatie\SqlCommenter\Commenters\RouteCommenter::class,
         Spatie\SqlCommenter\Commenters\JobCommenter::class => ['includeNamespace' => false],
-        Spatie\SqlCommenter\Commenters\FileCommenter::class => ['backtraceLimit' => 20],
+        Spatie\SqlCommenter\Commenters\FileCommenter::class => ['backtraceLimit' => 20, 'excludePathSegments' = []],
         Spatie\SqlCommenter\Commenters\CurrentUserCommenter::class,
         // Spatie\SqlCommenter\Commenters\FrameworkVersionCommenter::class,
         // Spatie\SqlCommenter\Commenters\DbDriverCommenter::class,

--- a/config/sql-commenter.php
+++ b/config/sql-commenter.php
@@ -13,7 +13,7 @@ return [
         Spatie\SqlCommenter\Commenters\ControllerCommenter::class => ['includeNamespace' => false],
         Spatie\SqlCommenter\Commenters\RouteCommenter::class,
         Spatie\SqlCommenter\Commenters\JobCommenter::class => ['includeNamespace' => false],
-        Spatie\SqlCommenter\Commenters\FileCommenter::class => ['backtraceLimit' => 20, 'excludePathSegments' = []],
+        Spatie\SqlCommenter\Commenters\FileCommenter::class => ['backtraceLimit' => 20, 'excludePathSegments' => []],
         Spatie\SqlCommenter\Commenters\CurrentUserCommenter::class,
         // Spatie\SqlCommenter\Commenters\FrameworkVersionCommenter::class,
         // Spatie\SqlCommenter\Commenters\DbDriverCommenter::class,

--- a/src/Commenters/FileCommenter.php
+++ b/src/Commenters/FileCommenter.php
@@ -10,7 +10,8 @@ use Spatie\SqlCommenter\Comment;
 class FileCommenter implements Commenter
 {
     public function __construct(
-        public int $backtraceLimit = 40
+        public int $backtraceLimit = 40,
+        public array $excludePathSegments = [],
     ) {
     }
 
@@ -27,10 +28,10 @@ class FileCommenter implements Commenter
                     return false;
                 }
 
-                $ignoredPathSegments = [
+                $ignoredPathSegments = array_merge([
                     'laravel-sql-commenter/src',
                     'laravel/framework',
-                ];
+                ], $this->excludePathSegments);
 
                 foreach ($ignoredPathSegments as $ignoredPathSegment) {
                     $segment = str_replace('/', DIRECTORY_SEPARATOR, "/{$ignoredPathSegment}/");


### PR DESCRIPTION
Currently, the package ignores both `laravel/framework` & `laravel-sql-commenter/src` path segments from the trace.

This change will allow us to add more trace path segments to ignore using config.

```php
return [
    'commenters' => [
        Spatie\SqlCommenter\Commenters\FileCommenter::class => [
            'backtraceLimit' => 20,
            'excludePathSegments' => ['tpetry/laravel-postgresql-enhanced']
        ],
    ], 
];
```