### PR TITLE
Added ability to use relative path in FileCommenter

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,11 @@ return [
         Spatie\SqlCommenter\Commenters\ControllerCommenter::class => ['includeNamespace' => false],
         Spatie\SqlCommenter\Commenters\RouteCommenter::class,
         Spatie\SqlCommenter\Commenters\JobCommenter::class => ['includeNamespace' => false],
-        Spatie\SqlCommenter\Commenters\FileCommenter::class => ['backtraceLimit' => 20],
+        Spatie\SqlCommenter\Commenters\FileCommenter::class => [
+            'backtraceLimit' => 20, 
+            'excludePathSegments' => [],
+            'useRelativePath' => false,
+        ],
         Spatie\SqlCommenter\Commenters\CurrentUserCommenter::class,
         // Spatie\SqlCommenter\Commenters\FrameworkVersionCommenter::class,
         // Spatie\SqlCommenter\Commenters\DbDriverCommenter::class,

--- a/config/sql-commenter.php
+++ b/config/sql-commenter.php
@@ -13,7 +13,11 @@ return [
         Spatie\SqlCommenter\Commenters\ControllerCommenter::class => ['includeNamespace' => false],
         Spatie\SqlCommenter\Commenters\RouteCommenter::class,
         Spatie\SqlCommenter\Commenters\JobCommenter::class => ['includeNamespace' => false],
-        Spatie\SqlCommenter\Commenters\FileCommenter::class => ['backtraceLimit' => 20, 'excludePathSegments' => []],
+        Spatie\SqlCommenter\Commenters\FileCommenter::class => [
+            'backtraceLimit' => 20,
+            'excludePathSegments' => [],
+            'useRelativePath' => false,
+        ],
         Spatie\SqlCommenter\Commenters\CurrentUserCommenter::class,
         // Spatie\SqlCommenter\Commenters\FrameworkVersionCommenter::class,
         // Spatie\SqlCommenter\Commenters\DbDriverCommenter::class,

--- a/src/Commenters/FileCommenter.php
+++ b/src/Commenters/FileCommenter.php
@@ -50,11 +50,12 @@ class FileCommenter implements Commenter
             return null;
         }
 
+        $filePath = $this->useRelativePath && str_starts_with($frame->file, base_path())
+            ? substr($frame->file, strlen(base_path()) + 1)
+            : $frame->file;
+
         return [
-            Comment::make('file', $this->useRelativePath && strpos($frame->file, base_path()) === 0
-                ? substr($frame->file, strlen(base_path()) + 1)
-                : $frame->file
-            ),
+            Comment::make('file', $filePath),
             Comment::make('line', $frame->lineNumber),
         ];
     }

--- a/src/Commenters/FileCommenter.php
+++ b/src/Commenters/FileCommenter.php
@@ -10,9 +10,11 @@ use Spatie\SqlCommenter\Comment;
 class FileCommenter implements Commenter
 {
     public function __construct(
-        public int $backtraceLimit = 40,
+        public int   $backtraceLimit = 40,
         public array $excludePathSegments = [],
-    ) {
+        public bool  $useRelativePath = false,
+    )
+    {
     }
 
     /** @return Comment|Comment[]|null */
@@ -44,12 +46,15 @@ class FileCommenter implements Commenter
                 return true;
             });
 
-        if (! $frame) {
+        if (!$frame) {
             return null;
         }
 
         return [
-            Comment::make('file', $frame->file),
+            Comment::make('file', $this->useRelativePath && strpos($frame->file, base_path()) === 0
+                ? substr($frame->file, strlen(base_path()) + 1)
+                : $frame->file
+            ),
             Comment::make('line', $frame->lineNumber),
         ];
     }

--- a/tests/Commenters/FileCommenterTest.php
+++ b/tests/Commenters/FileCommenterTest.php
@@ -27,3 +27,16 @@ it('logs the file it originated in with eloquent', function () {
 
     User::count();
 });
+
+it('logs the file use relative path', function () {
+    $this->addCommenterToConfig(FileCommenter::class, ['useRelativePath' => true]);
+
+    Event::listen(QueryExecuted::class, function (QueryExecuted $event) {
+        expect($event->sql)->not()->toContainComment('file', __FILE__);
+        expect($event->sql)->toContainComment('file', substr(__FILE__, strlen(__DIR__) + 1));
+    });
+
+    app()->setBasePath(__DIR__);
+    User::count();
+});
+


### PR DESCRIPTION
Full file paths are not so good when different file system paths are used for further releases. Like a /releases/1/laravel_app, /releases/2/laravel_app & etc.